### PR TITLE
Make a Path's commands accessible

### DIFF
--- a/fontkit.d.ts
+++ b/fontkit.d.ts
@@ -36,6 +36,11 @@ export interface Path {
   cbox: BoundingBox;
 
   /**
+   * This property represents the commands to draw an SVG path.
+   */
+  commands: { args: number[], command: string }[];
+
+  /**
    * Moves the virtual pen to the given x, y coordinates.
    */
   moveTo(x: number, y: number): void;


### PR DESCRIPTION
Making a path's commands accessible would be useful for users to apply some transformation to the path (e.g. move the entire path horizontally by adding offsets to `args`).