### PR TITLE
Fix version types

### DIFF
--- a/src/tables/hhea.js
+++ b/src/tables/hhea.js
@@ -1,19 +1,20 @@
-import r from '@pdf-lib/restructure';
+import r from "@pdf-lib/restructure";
 
 // horizontal header
 export default new r.Struct({
-  version:              r.int32,
-  ascent:               r.int16,   // Distance from baseline of highest ascender
-  descent:              r.int16,   // Distance from baseline of lowest descender
-  lineGap:              r.int16,   // Typographic line gap
-  advanceWidthMax:      r.uint16,  // Maximum advance width value in 'hmtx' table
-  minLeftSideBearing:   r.int16,   // Maximum advance width value in 'hmtx' table
-  minRightSideBearing:  r.int16,   // Minimum right sidebearing value
-  xMaxExtent:           r.int16,
-  caretSlopeRise:       r.int16,   // Used to calculate the slope of the cursor (rise/run); 1 for vertical
-  caretSlopeRun:        r.int16,   // 0 for vertical
-  caretOffset:          r.int16,   // Set to 0 for non-slanted fonts
-  reserved:             new r.Reserved(r.int16, 4),
-  metricDataFormat:     r.int16,   // 0 for current format
-  numberOfMetrics:      r.uint16   // Number of advance widths in 'hmtx' table
+	majorVersion: r.uint16,
+	minorVersion: r.uint16,
+	ascent: r.int16, // Distance from baseline of highest ascender
+	descent: r.int16, // Distance from baseline of lowest descender
+	lineGap: r.int16, // Typographic line gap
+	advanceWidthMax: r.uint16, // Maximum advance width value in 'hmtx' table
+	minLeftSideBearing: r.int16, // Maximum advance width value in 'hmtx' table
+	minRightSideBearing: r.int16, // Minimum right sidebearing value
+	xMaxExtent: r.int16,
+	caretSlopeRise: r.int16, // Used to calculate the slope of the cursor (rise/run); 1 for vertical
+	caretSlopeRun: r.int16, // 0 for vertical
+	caretOffset: r.int16, // Set to 0 for non-slanted fonts
+	reserved: new r.Reserved(r.int16, 4),
+	metricDataFormat: r.int16, // 0 for current format
+	numberOfMetrics: r.uint16, // Number of advance widths in 'hmtx' table
 });

--- a/src/tables/vhea.js
+++ b/src/tables/vhea.js
@@ -1,19 +1,19 @@
-import r from '@pdf-lib/restructure';
+import r from "@pdf-lib/restructure";
 
 // Vertical Header Table
 export default new r.Struct({
-  version:                r.uint16,  // Version number of the Vertical Header Table
-  ascent:                 r.int16,   // The vertical typographic ascender for this font
-  descent:                r.int16,   // The vertical typographic descender for this font
-  lineGap:                r.int16,   // The vertical typographic line gap for this font
-  advanceHeightMax:       r.int16,   // The maximum advance height measurement found in the font
-  minTopSideBearing:      r.int16,   // The minimum top side bearing measurement found in the font
-  minBottomSideBearing:   r.int16,   // The minimum bottom side bearing measurement found in the font
-  yMaxExtent:             r.int16,
-  caretSlopeRise:         r.int16,   // Caret slope (rise/run)
-  caretSlopeRun:          r.int16,
-  caretOffset:            r.int16,   // Set value equal to 0 for nonslanted fonts
-  reserved:               new r.Reserved(r.int16, 4),
-  metricDataFormat:       r.int16,   // Set to 0
-  numberOfMetrics:        r.uint16   // Number of advance heights in the Vertical Metrics table
+	version: r.uint32, // Version number of the Vertical Header Table
+	ascent: r.int16, // The vertical typographic ascender for this font
+	descent: r.int16, // The vertical typographic descender for this font
+	lineGap: r.int16, // The vertical typographic line gap for this font
+	advanceHeightMax: r.int16, // The maximum advance height measurement found in the font
+	minTopSideBearing: r.int16, // The minimum top side bearing measurement found in the font
+	minBottomSideBearing: r.int16, // The minimum bottom side bearing measurement found in the font
+	yMaxExtent: r.int16,
+	caretSlopeRise: r.int16, // Caret slope (rise/run)
+	caretSlopeRun: r.int16,
+	caretOffset: r.int16, // Set value equal to 0 for nonslanted fonts
+	reserved: new r.Reserved(r.int16, 4),
+	metricDataFormat: r.int16, // Set to 0
+	numberOfMetrics: r.uint16, // Number of advance heights in the Vertical Metrics table
 });


### PR DESCRIPTION
The version readings in the hhea and vhea tables are currently not appropriate.
https://docs.microsoft.com/en-us/typography/opentype/spec/hhea
https://docs.microsoft.com/en-us/typography/opentype/spec/vhea

According to these, there are two versions in hhea, major and minor. They are both uint16, so the current single int32 `version` did not cause any problems.
In vhea, however, there is one `version`, and it seems to be `uint32`, not `uint16`. Currently, this causes a two-byte gap, and `numberOfMetrics` will always return zero. And it's also causing problems with reading the vmtx table.
