### PR TITLE
Update import statement for fontkit in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Fontkit is an advanced font engine for Node and the browser, used by [PDFKit](ht
 ## Example
 
 ```js
-import fontkit from '@pdf-lib/fontkit';
+import * as fontkit from '@pdf-lib/fontkit';
 import fs from 'fs';
 
 // open a font synchronously


### PR DESCRIPTION
This commit updates the import statement for the `fontkit` library in the README.md file. 

Previously, the import statement was written as `import fontkit from '@pdf-lib/fontkit';`. However, this might cause issues if the library does not have a default export. 

To ensure compatibility with different module systems, the import statement has been changed to `import * as fontkit from '@pdf-lib/fontkit';`. This syntax imports all exports from the `fontkit` library into an object named `fontkit`, which can then be used to access the library's features.